### PR TITLE
fix case of "removeSubdomain" to match api

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -194,7 +194,7 @@ func (api *API) RemoveSubDomain(domain string, subdomain string) (*Status, error
 		subdomain,
 	}
 
-	if err := api.Call("removeSubDomain", args, &result); err != nil || result != "OK" {
+	if err := api.Call("removeSubdomain", args, &result); err != nil || result != "OK" {
 		return &Status{
 			Status: "failed",
 			Cause:  result,


### PR DESCRIPTION
`removeSubDomain` is wrong. The documentation in https://www.loopia.se/api/removesubdomain/ 
states it should be `removeSubdomain`
The server will throw a method lookup error if unchanged.