### PR TITLE
Remove CustomerNumber from authentication parameters

### DIFF
--- a/loopia.go
+++ b/loopia.go
@@ -9,10 +9,9 @@ const APIURL string = "https://api.loopia.se/RPCSERV"
 
 // API Struct to store runtime info
 type API struct {
-	Username       string
-	Password       string
-	RPCEndpoint    string
-	CustomerNumber string
+	Username    string
+	Password    string
+	RPCEndpoint string
 }
 
 // XMLRPCClient to interact with Loopia XMLRPC
@@ -25,7 +24,6 @@ func (api *API) getAuthenticationArgs() []interface{} {
 	return []interface{}{
 		api.Username,
 		api.Password,
-		api.CustomerNumber,
 	}
 }
 
@@ -41,8 +39,7 @@ func (api *API) Call(serviceMethod string, args []interface{}, reply interface{}
 func New(username string, password string) (*API, error) {
 	return &API{
 		RPCEndpoint: APIURL,
-		Username: username,
-		Password: password,
-		CustomerNumber: "",
+		Username:    username,
+		Password:    password,
 	}, nil
 }


### PR DESCRIPTION
I'm using this library via https://github.com/Identitry/cert-manager-webhook-loopia - and unfortunately it seems to be broken at the moment.

It appears Loopia changed the authentication parameters that should be prepended to each request to no longer include the Customer Number. Their documentation (https://www.loopia.com/api/authentication/) supports this.

This PR removes CustomerNumber from `getAuthenticationArgs()` and related structs. The changes seem to fix the problems in `cert-manager-webhook-loopia`, but I have not done any further testing of the library. There could be API calls that actually expect the CustomerNumber along with the username and password, so further investigation might be required before merging.